### PR TITLE
feat(backend): DB setup (SQLModel + SQLite), Group model, auto table creation

### DIFF
--- a/backend/app/db.py
+++ b/backend/app/db.py
@@ -1,0 +1,17 @@
+from sqlmodel import SQLModel, create_engine, Session
+import os
+
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./local.db")
+
+# needed for SQLite threads; harmless for Postgres
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+engine = create_engine(DATABASE_URL, echo=False, connect_args=connect_args)
+
+def init_db():
+    # import models so SQLModel sees the tables
+    from . import models  # noqa: F401
+    SQLModel.metadata.create_all(engine)
+
+def get_session():
+    with Session(engine) as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware 
+from fastapi.middleware.cors import CORSMiddleware
+from .db import init_db  
 
 app = FastAPI(title="Expense Splitter API", version="0.1.0")
 
@@ -11,6 +12,10 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+@app.on_event("startup")
+def on_startup():
+    init_db() #creates tables on app boot
 
 @app.get("/health")
 def health():

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,9 @@
+from sqlmodel import SQLModel, Field
+from typing import Optional
+from datetime import datetime
+
+class Group(SQLModel, table=True):
+    __tablename__ = "groups"  # avoid reserved word 'group'
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,11 +3,14 @@ anyio==4.10.0
 click==8.2.1
 exceptiongroup==1.3.0
 fastapi==0.116.1
+greenlet==3.2.4
 h11==0.16.0
 idna==3.10
 pydantic==2.11.7
 pydantic_core==2.33.2
 sniffio==1.3.1
+SQLAlchemy==2.0.43
+sqlmodel==0.0.24
 starlette==0.47.2
 typing-inspection==0.4.1
 typing_extensions==4.14.1


### PR DESCRIPTION
- Add database layer using SQLModel.
- Use SQLite for local dev (DATABASE_URL=sqlite:///./local.db
- Define Group table (id, name, created_at)
- Create tables automatically on app startup via init_db().
