### PR TITLE
feat(expenses): POST/GET expenses with equal split across group members

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .db import init_db  
-from .routers import groups, members
+from .routers import groups, members, expenses
 
 app = FastAPI(title="Expense Splitter API", version="0.1.0")
 
@@ -25,3 +25,4 @@ def health():
 
 app.include_router(groups.router)
 app.include_router(members.router)
+app.include_router(expenses.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -20,6 +20,25 @@ class Group(SQLModel, table=True):
 class Member(SQLModel, table=True):
     __tablename__ = "members"
     id: Optional[int] = Field(default=None, primary_key=True)
+    group_id: int = Field(foreign_key="groups.id")
     name: str
     email: Optional[str] = None
     created_at: datetime = Field(default_factory=utcnow, sa_column=Column(DateTime(timezone=True)))
+
+
+class Expense(SQLModel, table=True):
+    __tablename__ = "expenses"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    group_id: int  = Field(foreign_key="groups.id")
+    payer_id: int = Field(foreign_key="members.id")
+    amount: float
+    description: str=""
+    created_at: datetime = Field(default_factory=utcnow, sa_column=Column(DateTime(timezone=True)))
+
+class ExpenseShare(SQLModel, table=True):
+    __tablename__ = "expense_shares"
+    id: Optional[int] = Field(default=None, primary_key=True)
+    expense_id: int = Field(foreign_key="expenses.id")
+    member_id: int  = Field(foreign_key="members.id")
+    share: float #how much this member owes for this expense
+

--- a/backend/app/routers/expenses.py
+++ b/backend/app/routers/expenses.py
@@ -1,0 +1,58 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List
+from sqlmodel import select
+from ..db import get_session
+from ..models import Group, Member, Expense, ExpenseShare
+from ..schemas import ExpenseCreate, ExpenseRead, ExpenseShareRead
+
+router = APIRouter(prefix="/groups/{gid}/expenses", tags=["expenses"])
+
+@router.post("", response_model=ExpenseRead)
+def create_expense(gid: int, payload: ExpenseCreate, session=Depends(get_session)):
+    group = session.get(Group, gid)
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    payer = session.get(Member, payload.payer_id)
+    if not payer or payer.group_id != gid:
+        raise HTTPException(status_code=400, detail="Payer must be a member of this group")
+
+    members = session.exec(select(Member).where(Member.group_id == gid)).all()
+    if not members:
+        raise HTTPException(status_code=400, detail="Group has no members to split with")
+
+    exp = Expense(group_id=gid, payer_id=payload.payer_id, amount=payload.amount, description=payload.description)
+    session.add(exp)
+    session.commit()
+    session.refresh(exp)
+
+    per = round(payload.amount / len(members), 2)
+    shares = []
+    for m in members:
+        es = ExpenseShare(expense_id=exp.id, member_id=m.id, share=per)
+        session.add(es)
+        shares.append(ExpenseShareRead(member_id=m.id, share=per))
+    session.commit()
+
+    return ExpenseRead(
+        id=exp.id, group_id=exp.group_id, payer_id=exp.payer_id,
+        amount=exp.amount, description=exp.description, created_at=exp.created_at,
+        shares=shares
+    )
+
+@router.get("", response_model=List[ExpenseRead])
+def list_expenses(gid: int, session=Depends(get_session)):
+    if not session.get(Group, gid):
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    expenses = session.exec(select(Expense).where(Expense.group_id == gid).order_by(Expense.id.desc())).all()
+    out: List[ExpenseRead] = []
+    for e in expenses:
+        es = session.exec(select(ExpenseShare).where(ExpenseShare.expense_id == e.id)).all()
+        shares = [ExpenseShareRead(member_id=s.member_id, share=s.share) for s in es]
+        out.append(ExpenseRead(
+            id=e.id, group_id=e.group_id, payer_id=e.payer_id,
+            amount=e.amount, description=e.description, created_at=e.created_at,
+            shares=shares
+        ))
+    return out

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,6 +1,8 @@
 from sqlmodel import SQLModel
 from datetime import datetime
+from typing import List, Optional
 
+#---Groups---
 class GroupCreate(SQLModel):
     name: str
 
@@ -9,9 +11,10 @@ class GroupRead(SQLModel):
     name: str
     created_at: datetime
 
+#---Members---
 class MemberCreate(SQLModel):
     name: str
-    email: str | None = None
+    email: Optional[str] = None
 
 
 class MemberRead(SQLModel):
@@ -20,3 +23,23 @@ class MemberRead(SQLModel):
     name: str
     email: str | None
     created_at: datetime
+
+#---Expenses---
+class ExpenseCreate(SQLModel):
+    payer_id: int
+    amount: float
+    description: str = ""
+
+class ExpenseShareRead(SQLModel):
+    member_id: int
+    share: float
+
+class ExpenseRead(SQLModel):
+    id: int
+    group_id: int
+    payer_id: int
+    amount: float
+    description: str
+    created_at: datetime
+    shares: List[ExpenseShareRead]
+


### PR DESCRIPTION
## Summary
Add backend support for recording expenses in a group and returning equal per-member splits.

## What’s in this PR
- **Models**
  - `Expense` (id, group_id, payer_id, amount, description, created_at)
  - `ExpenseShare` (id, expense_id, member_id, share)
- **Schemas**
  - `ExpenseCreate`, `ExpenseShareRead`, `ExpenseRead`
- **Endpoints**
  - `POST /groups/{gid}/expenses` — create an expense; validates group & payer; splits amount equally among current members.
  - `GET  /groups/{gid}/expenses` — list group expenses including computed `shares`.
- **App wiring**
  - Register `expenses` router in `app.main`.

## How to test (manual)
1. Start API:
   ```bash
   cd backend
   source .venv/bin/activate
   export DATABASE_URL=sqlite:///./local.db
   uvicorn app.main:app --reload --port 8000
