### PR TITLE
feat(balances): GET /groups/{gid}/balances

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .db import init_db  
-from .routers import groups, members, expenses
+from .routers import groups, members, expenses, balances
 
 app = FastAPI(title="Expense Splitter API", version="0.1.0")
 
@@ -26,3 +26,4 @@ def health():
 app.include_router(groups.router)
 app.include_router(members.router)
 app.include_router(expenses.router)
+app.include_router(balances.router)

--- a/backend/app/routers/balances.py
+++ b/backend/app/routers/balances.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, Depends, HTTPException
+from typing import List, Dict
+from sqlmodel import select
+from ..db import get_session
+from ..models import Group, Member, Expense, ExpenseShare
+from ..schemas import BalanceRead
+
+router = APIRouter(prefix="/groups/{gid}/balances", tags=["balances"])
+
+@router.get("", response_model=List[BalanceRead])
+def get_balances(gid: int, session=Depends(get_session)):
+    group = session.get(Group, gid)
+    if not group:
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    members = session.exec(select(Member).where(Member.group_id == gid)).all()
+    if not members:
+        return []
+
+    nets: Dict[int, float] = {m.id: 0.0 for m in members}
+    names: Dict[int, str] = {m.id: m.name for m in members}
+
+    # credits: what members paid
+    for e in session.exec(select(Expense).where(Expense.group_id == gid)).all():
+        if e.payer_id in nets:
+            nets[e.payer_id] += float(e.amount)
+
+    # debits: what members owe
+    shares = session.exec(
+        select(ExpenseShare)
+        .join(Expense, ExpenseShare.expense_id == Expense.id)
+        .where(Expense.group_id == gid)
+    ).all()
+    for s in shares:
+        if s.member_id in nets:
+            nets[s.member_id] -= float(s.share)
+
+    out = [BalanceRead(member_id=i, name=names[i], net=round(v, 2)) for i, v in nets.items()]
+    out.sort(key=lambda x: x.net, reverse=True)
+    return out

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -43,3 +43,8 @@ class ExpenseRead(SQLModel):
     created_at: datetime
     shares: List[ExpenseShareRead]
 
+class BalanceRead(SQLModel):
+    member_id: int
+    name: str
+    net: float
+


### PR DESCRIPTION
## Summary
Adds per-member net balances for a group (total paid minus owed shares).

## Endpoint
- `GET /groups/{gid}/balances` — returns `[ { member_id, name, net } ]`
  - `net > 0`: member is owed
  - `net < 0`: member owes

## How it works
- Credits = sum of expenses paid by the member
- Debits  = sum of their `ExpenseShare` amounts
- Net     = Credits - Debits (rounded to 2 decimals); totals sum ≈ 0

## How to test
1. Create a group and 2–3 members.
2. Add one or more expenses with different payers.
3. Hit `/groups/{gid}/balances` and verify nets match the splits.

## Notes
- Dev DB is SQLite (`local.db`); safe to reset if needed.
